### PR TITLE
Fix/issue47 permissions and ownership

### DIFF
--- a/software/bcu/__main__.py
+++ b/software/bcu/__main__.py
@@ -91,8 +91,9 @@ async def backup(config: dict):
         "-aH",
         "--stats",
         "--delete",
+        f"--log-file={datetime.now().strftime('%Y-%m-%d')}_rsync.log",
         f"{nas_ip}::{source}/",
-        "/media/BackupHDD/backups"
+        "/media/BackupHDD/backups/current"
     ]
     LOG.debug(f"Backing up with command {' '.join(backup_command)}")
     process = await asyncio.create_subprocess_exec(
@@ -159,12 +160,15 @@ async def main() -> None:
     cfg = load_config(Path(args.config))
     await init(cfg["logger"])
     LOG.info(f"loading config file {args.config}")
-    await engage()
-    await backup(cfg["backup"])
+    try:
+        await engage()
+        await backup(cfg["backup"])
+    except RuntimeError:
+        LOG.error("Couldn't perform Backup. Disengaging and shutdown")
     await disengage()
-    await wait_before_shutdown(cfg)
-    await set_wakeup_time(config.get_sleep_time(cfg["process"]["time_between_backups"]))
     if not args.no_shutdown:
+        await wait_before_shutdown(cfg)
+        await set_wakeup_time(config.get_sleep_time(cfg["process"]["time_between_backups"]))
         await shutdown()
 
 

--- a/software/bcu/__main__.py
+++ b/software/bcu/__main__.py
@@ -84,6 +84,7 @@ async def backup(config: dict):
     nas_ip = resolve_ip(host_name_in_ssh_config="nas")
     LOG.debug(f"obtained IP Address of NAS: {nas_ip}")
     backup_command = [
+        "sudo",
         "rsync",
         "-aH",
         "--stats",

--- a/software/bcu/__main__.py
+++ b/software/bcu/__main__.py
@@ -63,6 +63,8 @@ async def engage() -> None:
             break
         LOG.warning("mounting of backupHDD failed, try another time")
         trials += 1
+    if not Path('/media/BackupHDD').is_mount():
+        raise RuntimeError("couldn't mount BackupHDD. Aborting.")
 
 
 async def handle_output(pipe, log_func: Callable):
@@ -84,6 +86,7 @@ async def backup(config: dict):
     nas_ip = resolve_ip(host_name_in_ssh_config="nas")
     LOG.debug(f"obtained IP Address of NAS: {nas_ip}")
     backup_command = [
+        "sudo",
         "rsync",
         "-aH",
         "--stats",

--- a/software/bcu/setup/sudoers
+++ b/software/bcu/setup/sudoers
@@ -3,5 +3,6 @@
 base ALL=(ALL) NOPASSWD: /sbin/shutdown
 base ALL=(ALL) NOPASSWD: /usr/bin/systemctl stop backupserver
 base ALL=(ALL) NOPASSWD: /usr/bin/systemctl start backupserver
+base ALL=(ALL) NOPASSWD: /usr/bin/rsync
 
 # maybe you have to enter these lines to `sudo visudo -f /etc/sudoers.d/base` or even `sudo visudo`


### PR DESCRIPTION
How does this fix work?
- The rsync command is run with `sudo`. Reason is that a normal user cannot write files in the name of a different user. This is necessary to keep permissions/uid/gids

Other changes along the way:
- when `no-shutdown` flag is set, the shutdown isn't even prepared. Otherwise it might lead to the PCU shutting off the device power
- raising a runtime error if mounting is not possible. Catch it and abort backup, shutdown gracefully then. Otherwise the script assumes that the hdd is mounted and writes the Backup on the SD-Card